### PR TITLE
First draft of an extractor registry schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
             - name: Run LinkML generators
               run: |
-                  for f in $(ls schemas/*.yml); do
+                  for f in $(ls schemas/*.y[a]ml); do
                     gen-pydantic -vvv --stacktrace $f
                   done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
             - name: Run LinkML generators
               run: |
-                  for f in $(ls schemas/*.y[a]ml); do
+                  for f in $(ls schemas/*.yml) $(ls schemas/*.yaml); do
                     gen-pydantic -vvv --stacktrace $f
                   done
 

--- a/schemas/base.yaml
+++ b/schemas/base.yaml
@@ -1,0 +1,43 @@
+---
+name: base
+id: https://www.marda-alliance.org/extractors/base
+prefixes:
+    linkml: https://w3id.org/linkml/
+    schema_org: http://schema.org/
+    dublin_core: http://purl.org/dc/elements/1.1/
+imports:
+    - linkml:types
+default_range: string
+description: >-
+    This file describes the generic slots used by models in the MaRDA extractors WG.
+
+
+slots:
+    id:
+        identifier: true
+        slot_uri: schema_org:identifier
+        required: true
+        description: >-
+            A unique identifier for the entry within the MaRDA
+            registry namespace, this should be a shorthand label rather than
+            a UUID. Only lower-case alphanumeric and dash ("-") characters
+            are permitted.
+        pattern: ^[a-z]+[a-z,0-9,-]*[a-z,0-9]+$
+    name:
+        slot_uri: schema_org:name
+        required: true
+        description: >-
+            A recognisable name for the entry.
+    description:
+        slot_uri: schema_org:description
+        required: true
+        description: >-
+            A human-readable outline of the entry, its format,
+            data content and uses.
+    subject:
+        slot_uri: dublin_core:subject
+        multivalued: true
+        description: >-
+            Any keywords, phrases or classification codes that are relevant
+            to the entry, e.g., particular scientific domains of applicability,
+            or experimental techniques.

--- a/schemas/extractor.yml
+++ b/schemas/extractor.yml
@@ -45,7 +45,11 @@ classes:
                 description: >-
                     A URL or URI for any online documentation associated with this
                     extractor.
-            usage_instructions:
+            usage:
                 required: false
                 description: >-
-                    Any MaRDA-specific usage instructions for this extractor.
+                    A command-line invocation of the parser, to be available after installation instructions have been followed.
+            instructions:
+                required: false
+                description: >-
+                    Any usage or installation instructions for this extractor.

--- a/schemas/extractor.yml
+++ b/schemas/extractor.yml
@@ -1,0 +1,70 @@
+---
+name: extractor
+id: https://www.marda-alliance.org/extractors/extractor
+prefixes:
+    linkml: https://w3id.org/linkml/
+    schema_org: http://schema.org/
+    dublin_core: http://purl.org/dc/elements/1.1/
+imports:
+    - linkml:types
+default_range: string
+description: >-
+    This file describes the `Extractor` model created by the MaRDA extractors WG.
+
+
+classes:
+    Extractor:
+        description: >-
+            A code object or web service that when executed can read a file with specific file type, or a
+            set of files with a given structure, and extract or transform the scientific data
+            and/or metadata contained within the file.
+        close_mappings:
+            - schema_org:SoftwareApplication
+            - schema_org:ServiceChannel
+            - dublin_core:Software
+            - dublin_core:Service
+        attributes:
+            id:
+                identifier: true
+                slot_uri: schema_org:identifier
+                required: true
+                description: >-
+                    A unique identifier for the format within the MaRDA
+                    registry namespace, this should be a shorthand label rather than
+                    a UUID. Only lower-case alphanumeric and dash ("-") characters
+                    are permitted.
+                pattern: ^[a-z]+[a-z,0-9,-]*[a-z,0-9]+$
+            name:
+                slot_uri: schema_org:name
+                required: true
+                description: >-
+                    A recognisable name for the extractor.
+            description:
+                slot_uri: schema_org:description
+                required: true
+                description: >-
+                    A human-readable outline of the extractor.
+            version:
+                slot_uri: dublin_core:version
+                required: true
+                description: >-
+                    A version tag for the registered extractor.
+            source_repository_url:
+                required: false
+                description: >-
+                    A URL or URI for a source code repository associated with this extractor.
+            documentation_url:
+                required: false
+                description: >-
+                    A URL or URI for any online documentation associated with this extractor.
+            usage_instructions:
+                required: false
+                description: >-
+                    Any MaRDA-specific usage instructions for this extractor.
+            subject:
+                slot_uri: dublin_core:subject
+                multivalued: true
+                description: >-
+                    Any keywords, phrases or classification codes that are relevant
+                    to the file type, e.g., particular scientific domains of applicability,
+                    or experimental techniques.

--- a/schemas/extractor.yml
+++ b/schemas/extractor.yml
@@ -48,7 +48,8 @@ classes:
             usage:
                 required: false
                 description: >-
-                    A command-line invocation of the parser, to be available after installation instructions have been followed.
+                    A command-line invocation of the parser, to be available after
+                    installation instructions have been followed.
             instructions:
                 required: false
                 description: >-

--- a/schemas/extractor.yml
+++ b/schemas/extractor.yml
@@ -15,8 +15,10 @@ description: >-
 classes:
     Extractor:
         description: >-
-            A code object or web service that when executed can read a file with specific file type, or a
-            set of files with a given structure, and extract or transform the scientific data
+            A code object or web service that when executed can read a file with specific
+            file type, or a
+            set of files with a given structure, and extract or transform the scientific
+            data
             and/or metadata contained within the file.
         close_mappings:
             - schema_org:SoftwareApplication
@@ -52,11 +54,13 @@ classes:
             source_repository_url:
                 required: false
                 description: >-
-                    A URL or URI for a source code repository associated with this extractor.
+                    A URL or URI for a source code repository associated with this
+                    extractor.
             documentation_url:
                 required: false
                 description: >-
-                    A URL or URI for any online documentation associated with this extractor.
+                    A URL or URI for any online documentation associated with this
+                    extractor.
             usage_instructions:
                 required: false
                 description: >-

--- a/schemas/extractor.yml
+++ b/schemas/extractor.yml
@@ -17,10 +17,8 @@ classes:
     Extractor:
         description: >-
             A code object or web service that when executed can read a file with specific
-            file type, or a
-            set of files with a given structure, and extract or transform the scientific
-            data
-            and/or metadata contained within the file.
+            file type, or a set of files with a given structure, and extract or transform
+            the scientific data and/or metadata contained within the file.
         close_mappings:
             - schema_org:SoftwareApplication
             - schema_org:ServiceChannel

--- a/schemas/extractor.yml
+++ b/schemas/extractor.yml
@@ -7,6 +7,7 @@ prefixes:
     dublin_core: http://purl.org/dc/elements/1.1/
 imports:
     - linkml:types
+    - base
 default_range: string
 description: >-
     This file describes the `Extractor` model created by the MaRDA extractors WG.
@@ -25,27 +26,12 @@ classes:
             - schema_org:ServiceChannel
             - dublin_core:Software
             - dublin_core:Service
+        slots:
+            - id
+            - name
+            - description
+            - subject
         attributes:
-            id:
-                identifier: true
-                slot_uri: schema_org:identifier
-                required: true
-                description: >-
-                    A unique identifier for the format within the MaRDA
-                    registry namespace, this should be a shorthand label rather than
-                    a UUID. Only lower-case alphanumeric and dash ("-") characters
-                    are permitted.
-                pattern: ^[a-z]+[a-z,0-9,-]*[a-z,0-9]+$
-            name:
-                slot_uri: schema_org:name
-                required: true
-                description: >-
-                    A recognisable name for the extractor.
-            description:
-                slot_uri: schema_org:description
-                required: true
-                description: >-
-                    A human-readable outline of the extractor.
             version:
                 slot_uri: dublin_core:version
                 required: true
@@ -65,10 +51,3 @@ classes:
                 required: false
                 description: >-
                     Any MaRDA-specific usage instructions for this extractor.
-            subject:
-                slot_uri: dublin_core:subject
-                multivalued: true
-                description: >-
-                    Any keywords, phrases or classification codes that are relevant
-                    to the file type, e.g., particular scientific domains of applicability,
-                    or experimental techniques.

--- a/schemas/filetype.yml
+++ b/schemas/filetype.yml
@@ -7,6 +7,7 @@ prefixes:
     dublin_core: http://purl.org/dc/elements/1.1/
 imports:
     - linkml:types
+    - base
 default_range: string
 description: >-
     This file describes the `FileType` model created by the MaRDA extractors WG.
@@ -22,28 +23,12 @@ classes:
             - schema_org:fileFormat
             - schema_org:encodingFormat
             - dublin_core:format
+        slots:
+            - id
+            - description
+            - name
+            - subject
         attributes:
-            id:
-                identifier: true
-                slot_uri: schema_org:identifier
-                required: true
-                description: >-
-                    A unique identifier for the format within the MaRDA
-                    registry namespace, this should be a shorthand label rather than
-                    a UUID. Only lower-case alphanumeric and dash ("-") characters
-                    are permitted.
-                pattern: ^[a-z]+[a-z,0-9,-]*[a-z,0-9]+$
-            name:
-                slot_uri: schema_org:name
-                required: true
-                description: >-
-                    A recognisable name for the format.
-            description:
-                slot_uri: schema_org:description
-                required: true
-                description: >-
-                    A human-readable outline of the file type, its format,
-                    data content and uses.
             associated_vendors:
                 slot_uri: schema_org:vendor
                 multivalued: true
@@ -70,10 +55,3 @@ classes:
                 description: >-
                     If this is a subformat that follows a particular well-defined
                     standard, e.g., CIF, NeXus, then it can be listed here.
-            subject:
-                slot_uri: dublin_core:subject
-                multivalued: true
-                description: >-
-                    Any keywords, phrases or classification codes that are relevant
-                    to the file type, e.g., particular scientific domains of applicability,
-                    or experimental techniques.


### PR DESCRIPTION
Very rough first draft of this schema, with quite a lot of detail still to iron out:

- [ ] how to link each extractor function to a broader package?
- [x] usage instructions
- [ ] entrypoints (c.f. discussion about machine-actionable entrypoints, e.g. `python:pip:pymatgen:pymatgen.io.cif.read_cif` or `docker:docker.marda-alliance.org:pymatgen.cif`)
- [x] additional dublin core / RDA software registry metadata
- [x] a base level schema for "entries" that provides a single source for description/id etc. slots