### PR TITLE
Add file type links to schemas

### DIFF
--- a/examples/extractor/example_extractor.yml
+++ b/examples/extractor/example_extractor.yml
@@ -42,6 +42,6 @@ citations:
       contributors: A. Person
       type: software
 supported_filetypes:
-  - id: biologic-mpr
-    description: >-
-      Can parse biologic MPR provided its a full moon.
+    - id: biologic-mpr
+      description: >-
+          Can parse biologic MPR provided its a full moon.

--- a/examples/extractor/example_extractor.yml
+++ b/examples/extractor/example_extractor.yml
@@ -41,3 +41,7 @@ citations:
           - A. Nother
       contributors: A. Person
       type: software
+supported_filetypes:
+  - id: biologic-mpr
+    description: >-
+      Can parse biologic MPR provided its a full moon.

--- a/schemas/extractor.yml
+++ b/schemas/extractor.yml
@@ -16,6 +16,13 @@ description: >-
 
 classes:
 
+    SupportedFileTypes:
+       description: >-
+         Container for links to the file types that this extractor supports.
+       slots:
+         - id
+         - description
+
     Extractor:
         description: >-
             A code object or web service that when executed can read a file with specific
@@ -35,9 +42,7 @@ classes:
         attributes:
             supported_filetypes:
                 multivalued: true
-                pattern: ^[a-z]+[a-z,0-9,-]*[a-z,0-9]+$
-                description: >-
-                    A list of MaRDA file type IDs that are supported by this extractor.
+                range: SupportedFileTypes
             version:
                 slot_uri: schema_org:version
                 description: >-

--- a/schemas/extractor.yml
+++ b/schemas/extractor.yml
@@ -33,34 +33,33 @@ classes:
             - subject
             - citations
         attributes:
+            supported_filetypes:
+                multivalued: true
+                pattern: ^[a-z]+[a-z,0-9,-]*[a-z,0-9]+$
+                description: >-
+                    A list of MaRDA file type IDs that are supported by this extractor.
             version:
                 slot_uri: schema_org:version
-                required: true
                 description: >-
                     A version tag for the registered extractor.
             source_repository:
-                required: false
                 description: >-
                     A URL or URI for a source code repository associated with this
                     extractor.
             documentation:
-                required: false
                 description: >-
                     A URL or URI for any online documentation associated with this
                     extractor.
             license:
-                required: false
                 slot_uri: dublin_core:license
                 description: >-
                     A URL, URI or SPDX license identifier for a legal document giving
                     official permission to do something with the resource.
             usage:
-                required: false
                 multivalued: true
                 description: >-
                     A command-line invocation of the parser, to be available after
                     installation instructions have been followed.
             instructions:
-                required: false
                 description: >-
                     Any usage or installation instructions for this extractor.

--- a/schemas/extractor.yml
+++ b/schemas/extractor.yml
@@ -17,11 +17,11 @@ description: >-
 classes:
 
     SupportedFileTypes:
-       description: >-
-         Container for links to the file types that this extractor supports.
-       slots:
-         - id
-         - description
+        description: >-
+            Container for links to the file types that this extractor supports.
+        slots:
+            - id
+            - description
 
     Extractor:
         description: >-

--- a/schemas/filetype.yml
+++ b/schemas/filetype.yml
@@ -54,3 +54,11 @@ classes:
                 description: >-
                     If this is a subformat that follows a particular well-defined
                     standard, e.g., CIF, NeXus, then it can be listed here.
+
+            registered_extractors:
+                multivalued: true
+                pattern: ^[a-z]+[a-z,0-9,-]*[a-z,0-9]+$
+                description: >-
+                    A list of MaRDA extractor IDs that support this file type. This
+                    field
+                    should be auto-populated by a registry.


### PR DESCRIPTION
This PR adds two-way links between file types and extractors to the models (via ID).

Only the extractor -> supported_filetypes field should be provided manually, the file type -> registered_extractors field will be generated by database lookup.