### PR TITLE
Set "license" and "supported_filetypes" as required attrs.

### DIFF
--- a/examples/extractor/example_extractor.yml
+++ b/examples/extractor/example_extractor.yml
@@ -45,3 +45,5 @@ supported_filetypes:
     - id: biologic-mpr
       description: >-
           Can parse biologic MPR provided its a full moon.
+license:
+    spdx: MIT

--- a/schemas/base.yaml
+++ b/schemas/base.yaml
@@ -7,6 +7,7 @@ prefixes:
     schema_org: http://schema.org/
     dc: http://purl.org/dc/elements/1.1/
     dctypes: http://purl.org/dc/dcmitype/1.1
+    dublin_core: http://purl.org/dc/elements/1.1/
 imports:
     - linkml:types
 default_range: string

--- a/schemas/base.yaml
+++ b/schemas/base.yaml
@@ -5,8 +5,7 @@ id: https://www.marda-alliance.org/extractors/base
 prefixes:
     linkml: https://w3id.org/linkml/
     schema_org: http://schema.org/
-    dc: http://purl.org/dc/elements/1.1/
-    dctypes: http://purl.org/dc/dcmitype/1.1
+    dcmi_terms: http://purl.org/dc/dcmitype/1.1
     dublin_core: http://purl.org/dc/elements/1.1/
 imports:
     - linkml:types
@@ -18,7 +17,7 @@ classes:
     Citation:
         attributes:
             uri:
-                slot_uri: dc:identifier
+                slot_uri: dublin_core:identifier
                 required: false
                 description: >-
                     An unambiguous reference to the resource within a given context.
@@ -28,23 +27,23 @@ classes:
                     (DOI), and Uniform Resource Name (URN). Persistent identifiers
                     should be provided as HTTP URIs [from DC].
             creators:
-                slot_uri: dc:creator
+                slot_uri: dublin_core:creator
                 multivalued: true
                 description: >-
                     A list of the creators of the resource.
             contributors:
-                slot_uri: dc:contributor
+                slot_uri: dublin_core:contributor
                 multivalued: true
                 description: >-
                     A list of the contributors to the resource.
             title:
                 required: false
-                slot_uri: dc:title
+                slot_uri: dublin_core:title
                 description: >-
                     A name given to the resource [from DC].
             type:
                 required: false
-                slot_uri: dc:type
+                slot_uri: dublin_core:type
                 description: >-
                     Any bibliographic resource type (e.g., article, dataset, software)
                     enumerated in the DCMI Type Vocabulary.
@@ -85,14 +84,14 @@ slots:
             A human-readable outline of the entry, its format,
             data content and uses.
     subject:
-        slot_uri: dc:subject
+        slot_uri: dublin_core:subject
         multivalued: true
         description: >-
             Any keywords, phrases or classification codes that are relevant
             to the entry, e.g., particular scientific domains of applicability,
             or experimental techniques.
     citations:
-        slot_uri: dctypes:BibliographicReference
+        slot_uri: dcmi_types:BibliographicReference
         multivalued: true
         required: false
         range: Citation

--- a/schemas/base.yaml
+++ b/schemas/base.yaml
@@ -47,6 +47,17 @@ classes:
                 description: >-
                     Any bibliographic resource type (e.g., article, dataset, software)
                     enumerated in the DCMI Type Vocabulary.
+    License:
+        attributes:
+            uri:
+                required: false
+                description: >-
+                    An unambiguous reference to the resource within a given context.
+            spdx:
+                required: false
+                description: >-
+                    An SPDX License Identifier entry.
+
 
 
 
@@ -87,3 +98,11 @@ slots:
         description: >-
             A citation or citations for the entry, to be provided should it be used
             in academic work (or otherwise).
+    license:
+        slot_uri: dublin_core:license
+        required: true
+        range: License
+        description: >-
+            A URL, URI or SPDX license identifier for a legal document giving
+            official permission to do something with the resource.
+            

--- a/schemas/base.yaml
+++ b/schemas/base.yaml
@@ -50,10 +50,12 @@ classes:
     License:
         attributes:
             uri:
+                slot_uri: dc_terms:identifier
                 required: false
                 description: >-
                     An unambiguous reference to the resource within a given context.
             spdx:
+                slot_uri: dc_terms:identifier
                 required: false
                 description: >-
                     An SPDX License Identifier entry.

--- a/schemas/base.yaml
+++ b/schemas/base.yaml
@@ -105,4 +105,3 @@ slots:
         description: >-
             A URL, URI or SPDX license identifier for a legal document giving
             official permission to do something with the resource.
-

--- a/schemas/base.yaml
+++ b/schemas/base.yaml
@@ -5,8 +5,8 @@ id: https://www.marda-alliance.org/extractors/base
 prefixes:
     linkml: https://w3id.org/linkml/
     schema_org: http://schema.org/
-    dcmi_terms: http://purl.org/dc/dcmitype/1.1
-    dublin_core: http://purl.org/dc/elements/1.1/
+    dcmitype: http://purl.org/dc/dcmitype/1.1
+    dc_terms: http://purl.org/dc/terms/1.1/
 imports:
     - linkml:types
 default_range: string
@@ -17,7 +17,7 @@ classes:
     Citation:
         attributes:
             uri:
-                slot_uri: dublin_core:identifier
+                slot_uri: dc_terms:identifier
                 required: false
                 description: >-
                     An unambiguous reference to the resource within a given context.
@@ -27,23 +27,23 @@ classes:
                     (DOI), and Uniform Resource Name (URN). Persistent identifiers
                     should be provided as HTTP URIs [from DC].
             creators:
-                slot_uri: dublin_core:creator
+                slot_uri: dc_terms:creator
                 multivalued: true
                 description: >-
                     A list of the creators of the resource.
             contributors:
-                slot_uri: dublin_core:contributor
+                slot_uri: dc_terms:contributor
                 multivalued: true
                 description: >-
                     A list of the contributors to the resource.
             title:
                 required: false
-                slot_uri: dublin_core:title
+                slot_uri: dc_terms:title
                 description: >-
                     A name given to the resource [from DC].
             type:
                 required: false
-                slot_uri: dublin_core:type
+                slot_uri: dc_terms:type
                 description: >-
                     Any bibliographic resource type (e.g., article, dataset, software)
                     enumerated in the DCMI Type Vocabulary.
@@ -84,14 +84,14 @@ slots:
             A human-readable outline of the entry, its format,
             data content and uses.
     subject:
-        slot_uri: dublin_core:subject
+        slot_uri: dc_terms:subject
         multivalued: true
         description: >-
             Any keywords, phrases or classification codes that are relevant
             to the entry, e.g., particular scientific domains of applicability,
             or experimental techniques.
     citations:
-        slot_uri: dcmi_types:BibliographicReference
+        slot_uri: dcmitype:BibliographicReference
         multivalued: true
         required: false
         range: Citation
@@ -99,7 +99,7 @@ slots:
             A citation or citations for the entry, to be provided should it be used
             in academic work (or otherwise).
     license:
-        slot_uri: dublin_core:license
+        slot_uri: dc_terms:license
         required: true
         range: License
         description: >-

--- a/schemas/base.yaml
+++ b/schemas/base.yaml
@@ -105,4 +105,4 @@ slots:
         description: >-
             A URL, URI or SPDX license identifier for a legal document giving
             official permission to do something with the resource.
-            
+

--- a/schemas/extractor.yml
+++ b/schemas/extractor.yml
@@ -46,6 +46,7 @@ classes:
         attributes:
             supported_filetypes:
                 multivalued: true
+                required: true
                 range: SupportedFileTypes
                 description: >-
                     Container for links to the file types that this extractor supports.
@@ -63,6 +64,7 @@ classes:
                     extractor.
             license:
                 slot_uri: dublin_core:license
+                required: true
                 description: >-
                     A URL, URI or SPDX license identifier for a legal document giving
                     official permission to do something with the resource.

--- a/schemas/extractor.yml
+++ b/schemas/extractor.yml
@@ -5,7 +5,7 @@ id: https://www.marda-alliance.org/extractors/extractor
 prefixes:
     linkml: https://w3id.org/linkml/
     schema_org: http://schema.org/
-    dublin_core: http://purl.org/dc/elements/1.1/
+    dcmitype: http://purl.org/dc/dcmitype/1.1
 imports:
     - linkml:types
     - base
@@ -35,8 +35,8 @@ classes:
         close_mappings:
             - schema_org:SoftwareApplication
             - schema_org:ServiceChannel
-            - dublin_core:Software
-            - dublin_core:Service
+            - dcmitype:Software
+            - dcmitype:Service
         slots:
             - id
             - name

--- a/schemas/extractor.yml
+++ b/schemas/extractor.yml
@@ -43,6 +43,7 @@ classes:
             - description
             - subject
             - citations
+            - license
         attributes:
             supported_filetypes:
                 multivalued: true
@@ -62,12 +63,6 @@ classes:
                 description: >-
                     A URL or URI for any online documentation associated with this
                     extractor.
-            license:
-                slot_uri: dublin_core:license
-                required: true
-                description: >-
-                    A URL, URI or SPDX license identifier for a legal document giving
-                    official permission to do something with the resource.
             usage:
                 multivalued: true
                 description: >-


### PR DESCRIPTION
This should close #18.

I think the `license` is fairly straightforward, although perhaps a little more work could be done to validate against the SPDX list. In particular, it should be limited to either specifying an `uri:` followed by the URL, or `spdx:` / `spdx_license_identifier:` followed by the identifier code. We might decide to do this sooner rather than later, ideally as part of this PR.

As for the comment on `required` field for `supported_filetypes` raised by Matthew:

> Agreed, though we might get an awkward situation where an extractor wants to report that it supports loads of file types that we don't have in the registry, in which case they might leave the field empty rather than adding arbitrary strings?

The current schema already stipulates a `range: SupportedFileTypes` here, so either the user would keep the `Extractor` as a local-only implementation with a matching `Filetype` in their local schema, or they'd have to commit a `Filetype` first.