### PR TITLE
Try to fix details block in docs

### DIFF
--- a/docs/source/_templates/class.md.jinja2
+++ b/docs/source/_templates/class.md.jinja2
@@ -105,17 +105,21 @@ URI: {{ gen.uri_link(element) }}
 ### Direct
 
 <details>
+
 ```yaml
 {{gen.yaml(element)}}
 ```
+
 </details>
 
 ### Induced
 
 <details>
+
 ```yaml
 {{gen.yaml(element, inferred=True)}}
 ```
+
 </details>
 
 {%- if footer -%}


### PR DESCRIPTION
It looks like this right now:

![2023-11-01-224231_502x681_scrot](https://github.com/marda-alliance/metadata_extractors_schema/assets/7916000/7c33c3b7-77a5-43a4-8809-44a8fe95fd56)

I've seen this before when markdown interacts with HTML, often just requires additional whitespace, which is what I'm trying here. Otherwise we'll just have to write `<pre>` blocks manually. I'll merge this straight away and check the deployment.