### PR TITLE
Avoid linkml-runtime-1.6.1

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-myst-parser~=2.0
-sphinx~=7.2
-sphinx-rtd-theme~=1.3
-sphinxcontrib-mermaid~=0.9
+myst-parser ~= 2.0
+sphinx ~= 7.2
+sphinx-rtd-theme ~= 1.3
+sphinxcontrib-mermaid ~= 0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-linkml >= 1.5.2, < 1.6.2
+linkml >= 1.5.2, < 1.6.1
 linkml-runtime != 1.6.1
 pre-commit ~= 2.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-linkml>=1.5.2<=1.6.1
+linkml>=1.5.2<1.6.2
 linkml-runtime!=1.6.1
 pre-commit~=2.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-linkml >= 1.5.2, < 1.6.1
+linkml >= 1.5.2, < 1.6.2
 linkml-runtime != 1.6.1
 pre-commit ~= 2.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-linkml>=1.5.2<2.0
+linkml>=1.5.2<=1.6.1
 linkml-runtime!=1.6.1
 pre-commit~=2.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 linkml>=1.5.2<2.0
+linkml-runtime!=1.6.1
 pre-commit~=2.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-linkml>=1.5.2<1.6.2
-linkml-runtime!=1.6.1
-pre-commit~=2.20
+linkml >= 1.5.2, < 1.6.2
+linkml-runtime != 1.6.1
+pre-commit ~= 2.20


### PR DESCRIPTION
Related to https://github.com/linkml/linkml/issues/1701, as it breaks our CI. Also https://github.com/linkml/linkml/issues/1694 breaks local imports.