### PR TITLE
Add `associated_file_extensions` to `FileType` schema

### DIFF
--- a/examples/FileType-example.yaml
+++ b/examples/FileType-example.yaml
@@ -15,7 +15,7 @@ associated_instruments:
     - Example Machine
     - Bunch of Junk
 associated_file_extensions:
-    - dat 
+    - dat
     - txt
 associated_software:
     - Example Software

--- a/examples/FileType-example.yaml
+++ b/examples/FileType-example.yaml
@@ -14,6 +14,9 @@ subject:
 associated_instruments:
     - Example Machine
     - Bunch of Junk
+associated_file_extensions:
+    - dat 
+    - txt
 associated_software:
     - Example Software
     - Bitrot Software

--- a/examples/FileType-netcdf.yaml
+++ b/examples/FileType-netcdf.yaml
@@ -11,8 +11,9 @@ associated_vendors:
     - UCAR
 subject:
     - climatology
-    - meteorology
-    - oceanography
+    - meteorology - oceanography
+associated_file_extensions:
+    - nc
 associated_software:
     - ArcGIS
     - OriginPro

--- a/schemas/filetype.yaml
+++ b/schemas/filetype.yaml
@@ -51,7 +51,9 @@ classes:
             associated_file_extensions:
                 multivalued: true
                 description: >-
-                    A list of any known file extensions that files of this `FileType` are found with. These may be used as a hint for `FileType` detection. Should omit the leading `'.'`, e.g. 'json' or 'txt'.
+                    A list of any known file extensions that files of this `FileType`
+                    are found with. These may be used as a hint for `FileType` detection.
+                    Should omit the leading `'.'`, e.g. 'json' or 'txt'.
             base_formats:
                 multivalued: true
                 range: FileType

--- a/schemas/filetype.yaml
+++ b/schemas/filetype.yaml
@@ -48,6 +48,11 @@ classes:
                 description: >-
                     A list of any known software (proprietary or otherwise) that produces
                     such `FileType`.
+            associated_file_extensions:
+                multivalued: true
+                description: >-
+                    A list of any known file extensions that this file is found with, to be used
+                    as a hint for file type detection. Should omit the leading '.', e.g., 'json' or 'txt'.
             base_formats:
                 multivalued: true
                 range: FileType

--- a/schemas/filetype.yaml
+++ b/schemas/filetype.yaml
@@ -54,6 +54,7 @@ classes:
                     A list of any known file extensions that files of this `FileType`
                     are found with. These may be used as a hint for `FileType` detection.
                     Should omit the leading `'.'`, e.g. 'json' or 'txt'.
+                pattern: ^[A-z,0-9]*[A-z,0-9]+$
             base_formats:
                 multivalued: true
                 range: FileType

--- a/schemas/filetype.yaml
+++ b/schemas/filetype.yaml
@@ -51,8 +51,10 @@ classes:
             associated_file_extensions:
                 multivalued: true
                 description: >-
-                    A list of any known file extensions that this file is found with, to be used
-                    as a hint for file type detection. Should omit the leading '.', e.g., 'json' or 'txt'.
+                    A list of any known file extensions that this file is found with,
+                    to be used
+                    as a hint for file type detection. Should omit the leading '.',
+                    e.g., 'json' or 'txt'.
             base_formats:
                 multivalued: true
                 range: FileType

--- a/schemas/filetype.yaml
+++ b/schemas/filetype.yaml
@@ -51,10 +51,7 @@ classes:
             associated_file_extensions:
                 multivalued: true
                 description: >-
-                    A list of any known file extensions that this file is found with,
-                    to be used
-                    as a hint for file type detection. Should omit the leading '.',
-                    e.g., 'json' or 'txt'.
+                    A list of any known file extensions that files of this `FileType` are found with. These may be used as a hint for `FileType` detection. Should omit the leading `'.'`, e.g. 'json' or 'txt'.
             base_formats:
                 multivalued: true
                 range: FileType


### PR DESCRIPTION
Currently, using the API and registry in tandem, you still have to choose which extractor to run.

This PR implements the `associated_file_extensions` field for `FileType`, which can be used to provide the initial hint of which extractor to run. This should be used carefully, and extractors should fail gracefully when run on types they do not understand.

Related to #45, and takes ideas from #9.

- This would exclude the case of e.g., POSCAR where the "file extension" is the whole filename, so could add some wording to that effect too
- Next related fields would come from #9, where file patterns can be used to improve the matching, but this then becomes more complicated.