### PR TITLE
Render comments in enums

### DIFF
--- a/docs/source/_templates/enum.md.jinja2
+++ b/docs/source/_templates/enum.md.jinja2
@@ -20,10 +20,10 @@ URI: {{ gen.uri_link(element) }}
 {% if element.permissible_values -%}
 ## Permissible Values
 
-| Value | Meaning | Description |
+| Value | Description | Comments |
 | --- | --- | --- |
 {% for pv in element.permissible_values.values() -%}
-| {{pv.text}} | {{pv.meaning}} | {{pv.description | wordwrap(80, wrapstring='<br/>')}} |
+| {{pv.text}} | {{pv.description | wordwrap(80, wrapstring='<br/>')}} | {{pv.comments| join(' ') | wordwrap(80, wrapstring='<br/>')}} |
 {% endfor %}
 {% else %}
 _This is a dynamic enum_

--- a/schemas/base.yaml
+++ b/schemas/base.yaml
@@ -285,7 +285,7 @@ enums:
             meta-only:
                 description: >-
                     This usage scope only returns metadata associated with the file,
-                    with the interpretatio of "metadata" left up to the `Extractor`.
+                    with the interpretation of "metadata" left up to the `Extractor`.
                 comments:
                     - >-
                       This may include, but is not limited to:


### PR DESCRIPTION
So, I remembered correctly: the instruction that `meta-only` should be JSON-serialisable is in the schema, but it's in the comment field. We can either render the comment field, or merge it with the description field. I'd prefer rendering it, hence modification of the jinja.